### PR TITLE
Server views refactor

### DIFF
--- a/xonstat/__init__.py
+++ b/xonstat/__init__.py
@@ -150,6 +150,33 @@ def main(global_config, **settings):
         accept="text/json"
     )
 
+    config.add_route("server_top_maps", "/server/{id:\d+}/topmaps")
+    config.add_view(
+        view=ServerTopMaps,
+        route_name="server_top_maps",
+        attr="json",
+        renderer="json",
+        accept="text/json"
+    )
+
+    config.add_route("server_top_players", "/server/{id:\d+}/topplayers")
+    config.add_view(
+        view=ServerTopPlayers,
+        route_name="server_top_players",
+        attr="json",
+        renderer="json",
+        accept="text/json"
+    )
+
+    config.add_route("server_top_scorers", "/server/{id:\d+}/topscorers")
+    config.add_view(
+        view=ServerTopScorers,
+        route_name="server_top_scorers",
+        attr="json",
+        renderer="json",
+        accept="text/json"
+    )
+
     config.add_route("server_info", "/server/{id:\d+}")
     config.add_view(
         view=ServerInfo,
@@ -162,7 +189,7 @@ def main(global_config, **settings):
         view=ServerInfo,
         route_name="server_info",
         attr="json",
-        renderer="server_info.mako",
+        renderer="json",
         accept="text/json"
     )
 

--- a/xonstat/__init__.py
+++ b/xonstat/__init__.py
@@ -141,14 +141,20 @@ def main(global_config, **settings):
                     accept="text/json")
 
     config.add_route("server_top_maps", "/server/{id:\d+}/topmaps")
+    config.add_view(view=ServerTopMaps, route_name="server_top_maps", attr="html",
+                    renderer="server_top_maps.mako", accept="text/html")
     config.add_view(view=ServerTopMaps, route_name="server_top_maps", attr="json", renderer="json",
                     accept="text/json")
 
-    config.add_route("server_top_players", "/server/{id:\d+}/topplayers")
+    config.add_route("server_top_players", "/server/{id:\d+}/topactive")
+    config.add_view(view=ServerTopPlayers, route_name="server_top_players", attr="html",
+                    renderer="server_top_players_index.mako", accept="text/html")
     config.add_view(view=ServerTopPlayers, route_name="server_top_players", attr="json",
                     renderer="json", accept="text/json")
 
     config.add_route("server_top_scorers", "/server/{id:\d+}/topscorers")
+    config.add_view(view=ServerTopScorers, route_name="server_top_scorers", attr="html",
+                    renderer="server_top_scorers.mako", accept="text/html")
     config.add_view(view=ServerTopScorers, route_name="server_top_scorers", attr="json",
                     renderer="json", accept="text/json")
 

--- a/xonstat/__init__.py
+++ b/xonstat/__init__.py
@@ -138,31 +138,31 @@ def main(global_config, **settings):
     config.add_view(view=ServerIndex, route_name="server_index", attr="html",
                     renderer="server_index.mako", accept="text/html")
     config.add_view(view=ServerIndex, route_name="server_index", attr="json", renderer="json",
-                    accept="text/json")
+                    accept="application/json")
 
     config.add_route("server_top_maps", "/server/{id:\d+}/topmaps")
     config.add_view(view=ServerTopMaps, route_name="server_top_maps", attr="html",
                     renderer="server_top_maps.mako", accept="text/html")
     config.add_view(view=ServerTopMaps, route_name="server_top_maps", attr="json", renderer="json",
-                    accept="text/json")
+                    accept="application/json")
 
     config.add_route("server_top_active", "/server/{id:\d+}/topactive")
     config.add_view(view=ServerTopPlayers, route_name="server_top_active", attr="html",
                     renderer="server_top_active.mako", accept="text/html")
     config.add_view(view=ServerTopPlayers, route_name="server_top_active", attr="json",
-                    renderer="json", accept="text/json")
+                    renderer="json", accept="application/json")
 
     config.add_route("server_top_scorers", "/server/{id:\d+}/topscorers")
     config.add_view(view=ServerTopScorers, route_name="server_top_scorers", attr="html",
                     renderer="server_top_scorers.mako", accept="text/html")
     config.add_view(view=ServerTopScorers, route_name="server_top_scorers", attr="json",
-                    renderer="json", accept="text/json")
+                    renderer="json", accept="application/json")
 
     config.add_route("server_info", "/server/{id:\d+}")
     config.add_view(view=ServerInfo, route_name="server_info", attr="html",
                     renderer="server_info.mako", accept="text/html")
     config.add_view(view=ServerInfo, route_name="server_info", attr="json", renderer="json",
-                    accept="text/json")
+                    accept="application/json")
 
     # MAP ROUTES
     config.add_route("map_index",      "/maps")

--- a/xonstat/__init__.py
+++ b/xonstat/__init__.py
@@ -9,6 +9,7 @@ from xonstat.models import initialize_db
 from xonstat.views import *
 from xonstat.security import *
 
+
 def main(global_config, **settings):
     """ This function returns a Pyramid WSGI application.
     """
@@ -133,11 +134,21 @@ def main(global_config, **settings):
     config.add_view(game_finder_json, route_name="game_index_json", renderer="jsonp")
 
     # SERVER ROUTES
-    config.add_route("server_index",      "/servers")
-    config.add_view(server_index,      route_name="server_index",      renderer="server_index.mako")
-
-    config.add_route("server_index_json", "/servers.json")
-    config.add_view(server_index_json, route_name="server_index_json", renderer="jsonp")
+    config.add_route("server_index", "/servers")
+    config.add_view(
+        view=ServerIndex,
+        route_name="server_index",
+        attr="html",
+        renderer="server_index.mako",
+        accept="text/html"
+    )
+    config.add_view(
+        view=ServerIndex,
+        route_name="server_index",
+        attr="json",
+        renderer="json",
+        accept="text/json"
+    )
 
     config.add_route("server_info",      "/server/{id:\d+}")
     config.add_view(server_info,      route_name="server_info",      renderer="server_info.mako")

--- a/xonstat/__init__.py
+++ b/xonstat/__init__.py
@@ -150,11 +150,21 @@ def main(global_config, **settings):
         accept="text/json"
     )
 
-    config.add_route("server_info",      "/server/{id:\d+}")
-    config.add_view(server_info,      route_name="server_info",      renderer="server_info.mako")
-
-    config.add_route("server_info_json", "/server/{id:\d+}.json")
-    config.add_view(server_info_json, route_name="server_info_json", renderer="jsonp")
+    config.add_route("server_info", "/server/{id:\d+}")
+    config.add_view(
+        view=ServerInfo,
+        route_name="server_info",
+        attr="html",
+        renderer="server_info.mako",
+        accept="text/html"
+    )
+    config.add_view(
+        view=ServerInfo,
+        route_name="server_info",
+        attr="json",
+        renderer="server_info.mako",
+        accept="text/json"
+    )
 
     # MAP ROUTES
     config.add_route("map_index",      "/maps")

--- a/xonstat/__init__.py
+++ b/xonstat/__init__.py
@@ -146,10 +146,10 @@ def main(global_config, **settings):
     config.add_view(view=ServerTopMaps, route_name="server_top_maps", attr="json", renderer="json",
                     accept="text/json")
 
-    config.add_route("server_top_players", "/server/{id:\d+}/topactive")
-    config.add_view(view=ServerTopPlayers, route_name="server_top_players", attr="html",
-                    renderer="server_top_players_index.mako", accept="text/html")
-    config.add_view(view=ServerTopPlayers, route_name="server_top_players", attr="json",
+    config.add_route("server_top_active", "/server/{id:\d+}/topactive")
+    config.add_view(view=ServerTopPlayers, route_name="server_top_active", attr="html",
+                    renderer="server_top_active.mako", accept="text/html")
+    config.add_view(view=ServerTopPlayers, route_name="server_top_active", attr="json",
                     renderer="json", accept="text/json")
 
     config.add_route("server_top_scorers", "/server/{id:\d+}/topscorers")

--- a/xonstat/__init__.py
+++ b/xonstat/__init__.py
@@ -135,63 +135,28 @@ def main(global_config, **settings):
 
     # SERVER ROUTES
     config.add_route("server_index", "/servers")
-    config.add_view(
-        view=ServerIndex,
-        route_name="server_index",
-        attr="html",
-        renderer="server_index.mako",
-        accept="text/html"
-    )
-    config.add_view(
-        view=ServerIndex,
-        route_name="server_index",
-        attr="json",
-        renderer="json",
-        accept="text/json"
-    )
+    config.add_view(view=ServerIndex, route_name="server_index", attr="html",
+                    renderer="server_index.mako", accept="text/html")
+    config.add_view(view=ServerIndex, route_name="server_index", attr="json", renderer="json",
+                    accept="text/json")
 
     config.add_route("server_top_maps", "/server/{id:\d+}/topmaps")
-    config.add_view(
-        view=ServerTopMaps,
-        route_name="server_top_maps",
-        attr="json",
-        renderer="json",
-        accept="text/json"
-    )
+    config.add_view(view=ServerTopMaps, route_name="server_top_maps", attr="json", renderer="json",
+                    accept="text/json")
 
     config.add_route("server_top_players", "/server/{id:\d+}/topplayers")
-    config.add_view(
-        view=ServerTopPlayers,
-        route_name="server_top_players",
-        attr="json",
-        renderer="json",
-        accept="text/json"
-    )
+    config.add_view(view=ServerTopPlayers, route_name="server_top_players", attr="json",
+                    renderer="json", accept="text/json")
 
     config.add_route("server_top_scorers", "/server/{id:\d+}/topscorers")
-    config.add_view(
-        view=ServerTopScorers,
-        route_name="server_top_scorers",
-        attr="json",
-        renderer="json",
-        accept="text/json"
-    )
+    config.add_view(view=ServerTopScorers, route_name="server_top_scorers", attr="json",
+                    renderer="json", accept="text/json")
 
     config.add_route("server_info", "/server/{id:\d+}")
-    config.add_view(
-        view=ServerInfo,
-        route_name="server_info",
-        attr="html",
-        renderer="server_info.mako",
-        accept="text/html"
-    )
-    config.add_view(
-        view=ServerInfo,
-        route_name="server_info",
-        attr="json",
-        renderer="json",
-        accept="text/json"
-    )
+    config.add_view(view=ServerInfo, route_name="server_info", attr="html",
+                    renderer="server_info.mako", accept="text/html")
+    config.add_view(view=ServerInfo, route_name="server_info", attr="json", renderer="json",
+                    accept="text/json")
 
     # MAP ROUTES
     config.add_route("map_index",      "/maps")

--- a/xonstat/templates/server_info.mako
+++ b/xonstat/templates/server_info.mako
@@ -11,6 +11,16 @@
   % endif
 </%block>
 
+<%def name="empty_rows(list, max_empty_rows)">
+  % for i in range(max_empty_rows - len(list)):
+    <tr>
+      <td>-</td>
+      <td>-</td>
+      <td>-</td>
+    </tr>
+  % endfor
+</%def>
+
 % if server is None:
   <h2>Sorry, that server wasn't found!</h2>
 
@@ -45,19 +55,16 @@
           </tr>
         </thead>
         <tbody>
-        <% i = 1 %>
-        % for (score_player_id, score_nick, score_value) in top_scorers:
+        % for ts in top_scorers:
           <tr>
-            <td>${i}</td>
-            % if score_player_id != '-':
-              <td class="no-stretch"><a href="${request.route_url('player_info', id=score_player_id)}" title="Go to the player info page for this player">${score_nick|n}</a></td>
-            % else:
-              <td class="no-stretch">${score_nick}</td>
-            % endif
-            <td>${score_value}</td>
+            <td>${ts.rank}</td>
+            <td class="no-stretch"><a href="${request.route_url('player_info', id=ts.player_id)}" title="Go to the player info page for this player">${ts.nick|n}</a></td>
+            <td>${ts.total_score}</td>
           </tr>
-          <% i = i+1 %>
         % endfor
+
+        ${empty_rows(top_scorers, 10)}
+
         </tbody>
       </table>
     </div>
@@ -73,19 +80,16 @@
           </tr>
         </thead>
         <tbody>
-        <% i = 1 %>
-        % for (player_id, nick, alivetime) in top_players:
+        % for tp in top_players:
           <tr>
-            <td>${i}</td>
-            % if player_id != '-':
-              <td class="no-stretch"><a href="${request.route_url('player_info', id=player_id)}" title="Go to the player info page for this player">${nick|n}</a></td>
-            % else:
-              <td class="no-stretch">${nick}</td>
-            % endif
-            <td>${alivetime}</td>
+            <td>${tp.rank}</td>
+            <td class="no-stretch"><a href="${request.route_url('player_info', id=tp.player_id)}" title="Go to the player info page for this player">${tp.nick|n}</a></td>
+            <td>${tp.alivetime}</td>
           </tr>
-          <% i = i+1 %>
         % endfor
+
+        ${empty_rows(top_players, 10)}
+
         </tbody>
       </table>
     </div>
@@ -101,19 +105,16 @@
           </tr>
         </thead>
         <tbody>
-        <% i = 1 %>
-        % for (map_id, name, count) in top_maps:
+        % for tm in top_maps:
           <tr>
-            <td>${i}</td>
-            % if map_id != '-':
-              <td class="no-stretch"><a href="${request.route_url('map_info', id=map_id)}" title="Go to the map info page for ${name}">${name}</a></td>
-            % else:
-              <td class="no-stretch">${name}</td>
-            % endif
-            <td>${count}</td>
+            <td>${tm.rank}</td>
+            <td class="no-stretch"><a href="${request.route_url('map_info', id=tm.map_id)}" title="Go to the map info page for ${tm.name}">${tm.name}</a></td>
+            <td>${tm.times_played}</td>
           </tr>
-          <% i = i+1 %>
         % endfor
+
+        ${empty_rows(top_maps, 10)}
+
         </tbody>
       </table>
     </div> 

--- a/xonstat/templates/server_info.mako
+++ b/xonstat/templates/server_info.mako
@@ -130,7 +130,7 @@
   % if len(recent_games) > 0:
     <div class="row">
       <div class="small-12 columns">
-        <h5>Most Recent Games</h5>
+        <h5>Most Recent Games <a href="${request.route_url('game_index', _query={'server_id':server.server_id})}"><i class="fa fa-plus-circle"></i></a></h5>
         <table class="table-hover table-condensed">
           <thead>
             <tr>
@@ -159,7 +159,6 @@
             % endfor
           </tbody>
         </table>
-        <p><a href="${request.route_url('game_index', _query={'server_id':server.server_id})}">More...</a></p>
       </div>
     </div>
   % endif

--- a/xonstat/templates/server_info.mako
+++ b/xonstat/templates/server_info.mako
@@ -122,7 +122,7 @@
 
   <div class="row">
     <div class="small-12 columns">
-      <small>*Most active stats are from the past 7 days</small>
+      <small>*Most active stats are from the past ${lifetime} days</small>
     </div>
   </div>
 

--- a/xonstat/templates/server_info.mako
+++ b/xonstat/templates/server_info.mako
@@ -45,7 +45,7 @@
 
   <div class="row">
     <div class="small-12 large-4 columns">
-      <h5>Top Scoring Players</h5>
+      <h5>Top Scoring Players <a href="${request.route_url('server_top_scorers', id=server.server_id)}" title="See more top scoring players for this server"><i class="fa fa-plus-circle"></i></a></h5>
       <table class="table-hover table-condensed">
         <thead>
           <tr>
@@ -70,7 +70,7 @@
     </div>
 
     <div class="small-12 large-4 columns">
-      <h5>Most Active Players</h5>
+      <h5>Most Active Players <a href="${request.route_url('server_top_active', id=server.server_id)}" title="See more active players for this server"><i class="fa fa-plus-circle"></i></a></h5>
       <table class="table-hover table-condensed">
         <thead>
           <tr>
@@ -95,7 +95,7 @@
     </div>
 
     <div class="small-12 large-4 columns">
-      <h5>Most Active Maps</h5>
+      <h5>Most Active Maps <a href="${request.route_url('server_top_maps', id=server.server_id)}" title="See more top maps for this server"><i class="fa fa-plus-circle"></i></a></h5>
       <table class="table-hover table-condensed">
         <thead>
           <tr>

--- a/xonstat/templates/server_top_active.mako
+++ b/xonstat/templates/server_top_active.mako
@@ -47,7 +47,7 @@
       <div class="small-12 large-6 large-offset-3 columns">
         <ul class="pagination">
           <li>
-            <a  href="${request.route_url('server_top_players', id=server_id, _query=query)}" name="Next Page">Next <i class="fa fa-arrow-right"></i></a>
+            <a  href="${request.route_url('server_top_active', id=server_id, _query=query)}" name="Next Page">Next <i class="fa fa-arrow-right"></i></a>
           </li>
         </ul>
       </div>

--- a/xonstat/templates/server_top_maps.mako
+++ b/xonstat/templates/server_top_maps.mako
@@ -36,7 +36,7 @@
         % endfor
         </tbody>
       </table>
-      <p class="text-center"><small>Note: these figures are from the past 7 days</small>
+      <p class="text-center"><small>Note: these figures are from the past ${lifetime} days</small>
     </div>
   </div>
 

--- a/xonstat/templates/server_top_maps.mako
+++ b/xonstat/templates/server_top_maps.mako
@@ -1,0 +1,55 @@
+<%inherit file="base.mako"/>
+<%namespace name="nav" file="nav.mako" />
+
+<%block name="navigation">
+  ${nav.nav('servers')}
+</%block>
+
+<%block name="title">
+  Server Top Map Index
+</%block>
+
+% if not top_maps and last is not None:
+  <h2 class="text-center">Sorry, no more maps!</h2>
+
+% elif not top_maps and last is None:
+  <h2 class="text-center">No maps found. Yikes, get playing!</h2>
+
+% else:
+  <div class="row">
+    <div class="small-12 large-6 large-offset-3 columns">
+      <table class="table-hover table-condensed">
+        <thead>
+          <tr>
+            <th class="small-2">#</th>
+            <th class="small-7">Map</th>
+            <th class="small-3">Times Played</th>
+          </tr>
+        </thead>
+        <tbody>
+        % for tm in top_maps:
+          <tr>
+            <td>${tm.rank}</td>
+            <td class="no-stretch"><a href="${request.route_url('map_info', id=tm.map_id)}" title="Go to the map info page for this map">${tm.name|n}</a></td>
+            <td>${tm.times_played}</td>
+          </tr>
+        % endfor
+        </tbody>
+      </table>
+      <p class="text-center"><small>Note: these figures are from the past 7 days</small>
+    </div>
+  </div>
+
+  % if len(top_maps) == 20:
+    <div class="row">
+      <div class="small-12 large-6 large-offset-3 columns">
+        <ul class="pagination">
+          <li>
+            <a  href="${request.route_url('server_top_maps', id=server_id, _query=query)}" name="Next Page">Next <i class="fa fa-arrow-right"></i></a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  % endif
+
+% endif

--- a/xonstat/templates/server_top_players_index.mako
+++ b/xonstat/templates/server_top_players_index.mako
@@ -38,7 +38,7 @@
         % endfor
         </tbody>
       </table>
-      <p class="text-center"><small>Note: these figures are from the past 7 days</small>
+      <p class="text-center"><small>Note: these figures are from the past ${lifetime} days</small>
     </div>
   </div>
 

--- a/xonstat/templates/server_top_players_index.mako
+++ b/xonstat/templates/server_top_players_index.mako
@@ -1,0 +1,57 @@
+<%inherit file="base.mako"/>
+<%namespace name="nav" file="nav.mako" />
+
+<%block name="navigation">
+  ${nav.nav('servers')}
+</%block>
+
+<%block name="title">
+  Server Active Players Index
+</%block>
+
+% if not top_players and start is not None:
+  <h2 class="text-center">Sorry, no more active players!</h2>
+
+% elif not top_players and start is None:
+  <h2 class="text-center">No active players found. Yikes, get playing!</h2>
+
+% else:
+  ##### ACTIVE PLAYERS #####
+  <div class="row">
+    <div class="small-12 large-6 large-offset-3 columns">
+      <table class="table-hover table-condensed">
+        <thead>
+          <tr>
+            <th class="small-2">#</th>
+            <th class="small-7">Nick</th>
+            <th class="small-3">Play Time</th>
+          </tr>
+        </thead>
+
+        <tbody>
+        % for tp in top_players:
+          <tr>
+            <td>${tp.rank}</td>
+            <td class="no-stretch"><a href="${request.route_url('player_info', id=tp.player_id)}" title="Go to the player info page for this player">${tp.nick|n}</a></td>
+            <td>${tp.alivetime}</td>
+          </tr>
+        % endfor
+        </tbody>
+      </table>
+      <p class="text-center"><small>Note: these figures are from the past 7 days</small>
+    </div>
+  </div>
+
+  % if len(top_players) == 20:
+    <div class="row">
+      <div class="small-12 large-6 large-offset-3 columns">
+        <ul class="pagination">
+          <li>
+            <a  href="${request.route_url('server_top_players', id=server_id, _query=query)}" name="Next Page">Next <i class="fa fa-arrow-right"></i></a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  % endif
+
+% endif

--- a/xonstat/templates/server_top_scorers.mako
+++ b/xonstat/templates/server_top_scorers.mako
@@ -1,0 +1,55 @@
+<%inherit file="base.mako"/>
+<%namespace name="nav" file="nav.mako" />
+
+<%block name="navigation">
+  ${nav.nav('servers')}
+</%block>
+
+<%block name="title">
+  Server Top Scorer Index
+</%block>
+
+% if not top_scorers and last is not None:
+  <h2 class="text-center">Sorry, no more players!</h2>
+
+% elif not top_scorers and last is None:
+  <h2 class="text-center">No players found. Yikes, get playing!</h2>
+
+% else:
+  <div class="row">
+    <div class="small-12 large-6 large-offset-3 columns">
+      <table class="table-hover table-condensed">
+        <thead>
+          <tr>
+            <th class="small-2">#</th>
+            <th class="small-7">Nick</th>
+            <th class="small-3">Score</th>
+          </tr>
+        </thead>
+        <tbody>
+        % for ts in top_scorers:
+          <tr>
+            <td>${ts.rank}</td>
+            <td class="no-stretch"><a href="${request.route_url('player_info', id=ts.player_id)}" title="Go to the player info page for this player">${ts.nick|n}</a></td>
+            <td>${ts.total_score}</td>
+          </tr>
+        % endfor
+        </tbody>
+      </table>
+      <p class="text-center"><small>Note: these figures are from the past 7 days</small>
+    </div>
+  </div>
+
+  % if len(top_scorers) == 20:
+    <div class="row">
+      <div class="small-12 large-6 large-offset-3 columns">
+        <ul class="pagination">
+          <li>
+            <a  href="${request.route_url('server_top_scorers', id=server_id, _query=query)}" name="Next Page">Next <i class="fa fa-arrow-right"></i></a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  % endif
+
+% endif

--- a/xonstat/templates/server_top_scorers.mako
+++ b/xonstat/templates/server_top_scorers.mako
@@ -36,7 +36,7 @@
         % endfor
         </tbody>
       </table>
-      <p class="text-center"><small>Note: these figures are from the past 7 days</small>
+      <p class="text-center"><small>Note: these figures are from the past ${lifetime} days</small>
     </div>
   </div>
 

--- a/xonstat/views/__init__.py
+++ b/xonstat/views/__init__.py
@@ -17,7 +17,8 @@ from xonstat.views.map    import map_info, map_index
 from xonstat.views.map    import map_info_json, map_index_json
 from xonstat.views.map    import map_captimes, map_captimes_json
 
-from xonstat.views.server import ServerIndex, ServerInfo
+from xonstat.views.server import ServerIndex, ServerTopMaps, ServerTopScorers, ServerTopPlayers
+from xonstat.views.server import ServerInfo
 
 from xonstat.views.search import search_q, search
 from xonstat.views.search import search_json

--- a/xonstat/views/__init__.py
+++ b/xonstat/views/__init__.py
@@ -17,8 +17,7 @@ from xonstat.views.map    import map_info, map_index
 from xonstat.views.map    import map_info_json, map_index_json
 from xonstat.views.map    import map_captimes, map_captimes_json
 
-from xonstat.views.server import server_info, server_info_json
-from xonstat.views.server import ServerIndex
+from xonstat.views.server import ServerIndex, ServerInfo
 
 from xonstat.views.search import search_q, search
 from xonstat.views.search import search_json

--- a/xonstat/views/__init__.py
+++ b/xonstat/views/__init__.py
@@ -17,9 +17,8 @@ from xonstat.views.map    import map_info, map_index
 from xonstat.views.map    import map_info_json, map_index_json
 from xonstat.views.map    import map_captimes, map_captimes_json
 
-from xonstat.views.server import server_info, server_index
-from xonstat.views.server import server_info_json
-from xonstat.views.server import server_index_json
+from xonstat.views.server import server_info, server_info_json
+from xonstat.views.server import ServerIndex
 
 from xonstat.views.search import search_q, search
 from xonstat.views.search import search_json

--- a/xonstat/views/server.py
+++ b/xonstat/views/server.py
@@ -11,13 +11,17 @@ log = logging.getLogger(__name__)
 
 
 class ServerIndex(object):
+    """Returns a list of servers."""
 
     def __init__(self, request):
+        """Common parameter parsing."""
+
         self.request = request
         self.page = request.params.get("page", 1)
         self.servers = self._data()
 
     def _data(self):
+        """Returns the data shared by all renderers."""
         try:
             server_q = DBSession.query(Server).order_by(Server.server_id.desc())
             servers = Page(server_q, self.page, items_per_page=25, url=page_url)
@@ -28,11 +32,13 @@ class ServerIndex(object):
         return servers
 
     def html(self):
+        """For rendering this data using something HTML-based."""
         return {
             'servers': self.servers,
         }
 
     def json(self):
+        """For rendering this data using JSON."""
         return {
             'servers': [s.to_dict() for s in self.servers],
         }

--- a/xonstat/views/server.py
+++ b/xonstat/views/server.py
@@ -33,7 +33,7 @@ class ServerIndex(object):
             servers = Page(server_q, self.page, items_per_page=25, url=page_url)
 
         except:
-            servers = None
+            raise HTTPNotFound
 
         return servers
 
@@ -62,15 +62,15 @@ class ServerInfoBase(object):
                                                      LEADERBOARD_LIFETIME)
         self.lifetime = int(raw_lifetime)
 
-        self.limit = request.matchdict.get("limit", limit)
-        self.last = request.matchdict.get("last", last)
+        self.limit = request.params.get("limit", limit)
+        self.last = request.params.get("last", last)
         self.now = datetime.utcnow()
 
 
 class ServerTopMaps(ServerInfoBase):
     """Returns the top maps played on a given server."""
 
-    def __init__(self, request, limit=None, last=None):
+    def __init__(self, request, limit=LEADERBOARD_COUNT, last=None):
         """Common parameter parsing."""
         super(ServerTopMaps, self).__init__(request, limit, last)
 
@@ -95,7 +95,7 @@ class ServerTopMaps(ServerInfoBase):
 
             top_maps = top_maps_q.all()
         except:
-            top_maps = None
+            raise HTTPNotFound
 
         return top_maps
 
@@ -113,7 +113,7 @@ class ServerTopMaps(ServerInfoBase):
 class ServerTopScorers(ServerInfoBase):
     """Returns the top scorers on a given server."""
 
-    def __init__(self, request, limit=None, last=None):
+    def __init__(self, request, limit=LEADERBOARD_COUNT, last=None):
         """Common parameter parsing."""
         super(ServerTopScorers, self).__init__(request, limit, last)
         self.top_scorers = self.raw()
@@ -142,7 +142,7 @@ class ServerTopScorers(ServerInfoBase):
             top_scorers = top_scorers_q.all()
 
         except:
-            top_scorers = None
+            raise HTTPNotFound
 
         return top_scorers
 
@@ -160,7 +160,7 @@ class ServerTopScorers(ServerInfoBase):
 class ServerTopPlayers(ServerInfoBase):
     """Returns the top players by playing time on a given server."""
 
-    def __init__(self, request, limit=None, last=None):
+    def __init__(self, request, limit=LEADERBOARD_COUNT, last=None):
         """Common parameter parsing."""
         super(ServerTopPlayers, self).__init__(request, limit, last)
         self.top_players = self.raw()
@@ -188,7 +188,7 @@ class ServerTopPlayers(ServerInfoBase):
             top_players = top_players_q.all()
 
         except:
-            top_players = None
+            raise HTTPNotFound
 
         return top_players
 
@@ -247,7 +247,6 @@ class ServerInfo(ServerInfoBase):
 
     def json(self):
         """For rendering this data using JSON."""
-
         return {
             'server': self.server.to_dict(),
             'top_players': self.top_players_v.json(),

--- a/xonstat/views/server.py
+++ b/xonstat/views/server.py
@@ -277,6 +277,7 @@ class ServerInfo(ServerInfoBase):
             'top_scorers': self.top_scorers_v.html(),
             'top_maps': self.top_maps_v.html(),
             'recent_games': self.recent_games,
+            'lifetime': self.lifetime,
         }
 
     def json(self):

--- a/xonstat/views/server.py
+++ b/xonstat/views/server.py
@@ -106,7 +106,6 @@ class ServerTopScorers(ServerInfoBase):
 
     def __init__(self, request):
         """Common parameter parsing."""
-
         super(ServerTopScorers, self).__init__(request)
         self.top_scorers = self.raw()
 
@@ -147,7 +146,6 @@ class ServerTopPlayers(ServerInfoBase):
 
     def __init__(self, request):
         """Common parameter parsing."""
-
         super(ServerTopPlayers, self).__init__(request)
         self.top_players = self.raw()
 
@@ -187,7 +185,6 @@ class ServerInfo(ServerInfoBase):
 
     def __init__(self, request):
         """Common parameter parsing."""
-
         super(ServerInfo, self).__init__(request)
 
     def raw(self):

--- a/xonstat/views/server.py
+++ b/xonstat/views/server.py
@@ -35,7 +35,8 @@ class ServerIndex(object):
             server_q = DBSession.query(Server).order_by(Server.server_id.desc())
             servers = Page(server_q, self.page, items_per_page=25, url=page_url)
 
-        except:
+        except Exception as e:
+            log.debug(e)
             raise HTTPNotFound
 
         return servers
@@ -128,7 +129,10 @@ class ServerTopMaps(ServerInfoBase):
             "times_played": tm.times_played,
         } for tm in self.top_maps]
 
-        return top_maps
+        return {
+            "server_id": self.server_id,
+            "top_maps": top_maps,
+        }
 
 
 class ServerTopScorers(ServerInfoBase):
@@ -198,7 +202,10 @@ class ServerTopScorers(ServerInfoBase):
             "score": ts.total_score,
         } for ts in self.top_scorers]
 
-        return top_scorers
+        return {
+            "server_id": self.server_id,
+            "top_scorers": top_scorers,
+        }
 
 
 class ServerTopPlayers(ServerInfoBase):
@@ -267,7 +274,10 @@ class ServerTopPlayers(ServerInfoBase):
             "time": ts.alivetime.total_seconds(),
         } for ts in self.top_players]
 
-        return top_players
+        return {
+            "server_id": self.server_id,
+            "top_players": top_players,
+        }
 
 
 class ServerInfo(ServerInfoBase):

--- a/xonstat/views/server.py
+++ b/xonstat/views/server.py
@@ -2,12 +2,19 @@ import logging
 import sqlalchemy.sql.functions as func
 import sqlalchemy.sql.expression as expr
 from datetime import datetime, timedelta
+from pyramid.httpexceptions import HTTPNotFound
 from webhelpers.paginate import Page
-from xonstat.models import *
+from xonstat.models import DBSession, Player, Server, Map, Game, PlayerGameStat
 from xonstat.util import page_url, html_colors
 from xonstat.views.helpers import RecentGame, recent_games_q
 
 log = logging.getLogger(__name__)
+
+
+# Defaults
+LEADERBOARD_LIFETIME = 30
+LEADERBOARD_COUNT = 10
+RECENT_GAMES_COUNT = 20
 
 
 class ServerIndex(object):
@@ -15,7 +22,6 @@ class ServerIndex(object):
 
     def __init__(self, request):
         """Common parameter parsing."""
-
         self.request = request
         self.page = request.params.get("page", 1)
         self.servers = self._data()
@@ -44,105 +50,113 @@ class ServerIndex(object):
         }
 
 
-def _server_info_data(request):
-    server_id = request.matchdict['id']
+class ServerInfo(object):
+    """Returns detailed information about a particular server."""
 
-    try:
-        leaderboard_lifetime = int(
-                request.registry.settings['xonstat.leaderboard_lifetime'])
-    except:
-        leaderboard_lifetime = 30
+    def __init__(self, request):
+        """Common parameter parsing."""
+        self.request = request
+        self.server_id = request.matchdict.get("id", None)
 
-    leaderboard_count = 10
-    recent_games_count = 20
+        raw_lifetime = request.registry.settings.get('xonstat.leaderboard_lifetime',
+                                                     LEADERBOARD_LIFETIME)
+        self.lifetime = int(raw_lifetime)
 
-    try:
-        server = DBSession.query(Server).filter_by(server_id=server_id).one()
+        self.now = datetime.utcnow()
+        self.server_info = self._data()
 
-        # top maps by total times played
-        top_maps = DBSession.query(Game.map_id, Map.name,
-                func.count()).\
-                filter(Map.map_id==Game.map_id).\
-                filter(Game.server_id==server.server_id).\
-                filter(Game.create_dt >
-                    (datetime.utcnow() - timedelta(days=leaderboard_lifetime))).\
-                order_by(expr.desc(func.count())).\
-                group_by(Game.map_id).\
-                group_by(Map.name).all()[0:leaderboard_count]
+    def _top_maps(self):
+        """Top maps on this server by total times played."""
+        try:
+            top_maps = DBSession.query(Game.map_id, Map.name, func.count())\
+                .filter(Map.map_id==Game.map_id)\
+                .filter(Game.server_id==self.server_id)\
+                .filter(Game.create_dt > (self.now - timedelta(days=self.lifetime)))\
+                .group_by(Game.map_id)\
+                .group_by(Map.name) \
+                .order_by(expr.desc(func.count()))\
+                .limit(LEADERBOARD_COUNT)
+        except:
+            top_maps = None
 
-        # top players by score
-        top_scorers = DBSession.query(Player.player_id, Player.nick,
-                func.sum(PlayerGameStat.score)).\
-                filter(Player.player_id == PlayerGameStat.player_id).\
-                filter(Game.game_id == PlayerGameStat.game_id).\
-                filter(Game.server_id == server.server_id).\
-                filter(Player.player_id > 2).\
-                filter(PlayerGameStat.create_dt >
-                        (datetime.utcnow() - timedelta(days=leaderboard_lifetime))).\
-                order_by(expr.desc(func.sum(PlayerGameStat.score))).\
-                group_by(Player.nick).\
-                group_by(Player.player_id).all()[0:leaderboard_count]
+        return top_maps
 
-        top_scorers = [(player_id, html_colors(nick), score) \
-                for (player_id, nick, score) in top_scorers]
+    def _top_scorers(self):
+        """Top scorers on this server by total score."""
+        try:
+            top_scorers = DBSession.query(Player.player_id, Player.nick,
+                                          func.sum(PlayerGameStat.score))\
+                .filter(Player.player_id == PlayerGameStat.player_id)\
+                .filter(Game.game_id == PlayerGameStat.game_id)\
+                .filter(Game.server_id == self.server_id)\
+                .filter(Player.player_id > 2)\
+                .filter(PlayerGameStat.create_dt >
+                        (self.now - timedelta(days=LEADERBOARD_LIFETIME)))\
+                .order_by(expr.desc(func.sum(PlayerGameStat.score)))\
+                .group_by(Player.nick)\
+                .group_by(Player.player_id)\
+                .limit(LEADERBOARD_COUNT)
 
-        # top players by playing time
-        top_players = DBSession.query(Player.player_id, Player.nick,
-                func.sum(PlayerGameStat.alivetime)).\
-                filter(Player.player_id == PlayerGameStat.player_id).\
-                filter(Game.game_id == PlayerGameStat.game_id).\
-                filter(Game.server_id == server.server_id).\
-                filter(Player.player_id > 2).\
-                filter(PlayerGameStat.create_dt >
-                        (datetime.utcnow() - timedelta(days=leaderboard_lifetime))).\
-                order_by(expr.desc(func.sum(PlayerGameStat.alivetime))).\
-                group_by(Player.nick).\
-                group_by(Player.player_id).all()[0:leaderboard_count]
+            # We can't call a Python function directly in our query, so we have to convert
+            # it out-of-band.
+            top_scorers = [(player_id, html_colors(nick), score)
+                           for (player_id, nick, score) in top_scorers]
+        except:
+            top_scorers = None
 
-        top_players = [(player_id, html_colors(nick), score) \
-                for (player_id, nick, score) in top_players]
+        return top_scorers
 
-        # recent games played in descending order
-        rgs = recent_games_q(server_id=server_id).limit(recent_games_count).all()
-        recent_games = [RecentGame(row) for row in rgs]
+    def _top_players(self):
+        """Top players on this server by total playing time."""
+        try:
+            top_players = DBSession.query(Player.player_id, Player.nick,
+                                          func.sum(PlayerGameStat.alivetime))\
+                .filter(Player.player_id == PlayerGameStat.player_id)\
+                .filter(Game.game_id == PlayerGameStat.game_id)\
+                .filter(Game.server_id == self.server_id)\
+                .filter(Player.player_id > 2)\
+                .filter(PlayerGameStat.create_dt > (self.now - timedelta(days=self.lifetime)))\
+                .order_by(expr.desc(func.sum(PlayerGameStat.alivetime)))\
+                .group_by(Player.nick)\
+                .group_by(Player.player_id)\
+                .limit(LEADERBOARD_COUNT)
 
-    except Exception as e:
-        server = None
-        recent_games = None
-        top_players = None
-        raise e
-    return {'server':server,
-            'recent_games':recent_games,
+            # We can't call a Python function directly in our query, so we have to convert
+            # it out-of-band.
+            top_players = [(player_id, html_colors(nick), score) \
+                    for (player_id, nick, score) in top_players]
+
+        except:
+            top_players = None
+
+        return top_players
+
+    def _data(self):
+        """Returns the data shared by all renderers."""
+        try:
+            server = DBSession.query(Server).filter_by(server_id=self.server_id).one()
+
+            top_maps = self._top_maps()
+            top_scorers = self._top_scorers()
+            top_players = self._top_players()
+
+            rgs = recent_games_q(server_id=self.server_id).limit(RECENT_GAMES_COUNT).all()
+            recent_games = [RecentGame(row) for row in rgs]
+        except:
+            raise HTTPNotFound
+
+        return {
+            'server': server,
+            'recent_games': recent_games,
             'top_players': top_players,
             'top_scorers': top_scorers,
             'top_maps': top_maps,
-            }
+        }
 
+    def html(self):
+        """For rendering this data using something HTML-based."""
+        return self.server_info
 
-def server_info(request):
-    """
-    List the stored information about a given server.
-    """
-    serverinfo_data =  _server_info_data(request)
-
-    # FIXME: code clone, should get these from _server_info_data
-    leaderboard_count = 10
-    recent_games_count = 20
-
-    for i in range(leaderboard_count-len(serverinfo_data['top_maps'])):
-        serverinfo_data['top_maps'].append(('-', '-', '-'))
-
-    for i in range(leaderboard_count-len(serverinfo_data['top_scorers'])):
-        serverinfo_data['top_scorers'].append(('-', '-', '-'))
-
-    for i in range(leaderboard_count-len(serverinfo_data['top_players'])):
-        serverinfo_data['top_players'].append(('-', '-', '-'))
-
-    return serverinfo_data
-
-
-def server_info_json(request):
-    """
-    List the stored information about a given server. JSON.
-    """
-    return [{'status':'not implemented'}]
+    def json(self):
+        """For rendering this data using JSON."""
+        return {"status":"Not implemented"}

--- a/xonstat/views/server.py
+++ b/xonstat/views/server.py
@@ -24,10 +24,10 @@ class ServerIndex(object):
         """Common parameter parsing."""
         self.request = request
         self.page = request.params.get("page", 1)
-        self.servers = self._data()
+        self.servers = self.raw()
 
-    def _data(self):
-        """Returns the data shared by all renderers."""
+    def raw(self):
+        """Returns the raw data shared by all renderers."""
         try:
             server_q = DBSession.query(Server).order_by(Server.server_id.desc())
             servers = Page(server_q, self.page, items_per_page=25, url=page_url)
@@ -50,8 +50,8 @@ class ServerIndex(object):
         }
 
 
-class ServerInfo(object):
-    """Returns detailed information about a particular server."""
+class ServerInfoBase(object):
+    """Baseline parameter parsing for Server URLs with a server_id in them."""
 
     def __init__(self, request):
         """Common parameter parsing."""
@@ -63,10 +63,18 @@ class ServerInfo(object):
         self.lifetime = int(raw_lifetime)
 
         self.now = datetime.utcnow()
-        self.server_info = self._data()
 
-    def _top_maps(self):
-        """Top maps on this server by total times played."""
+
+class ServerTopMaps(ServerInfoBase):
+    """Returns the top maps played on a given server."""
+
+    def __init__(self, request):
+        """Common parameter parsing."""
+        super(ServerTopMaps, self).__init__(request)
+        self.top_maps = self.raw()
+
+    def raw(self):
+        """Returns the raw data shared by all renderers."""
         try:
             top_maps = DBSession.query(Game.map_id, Map.name, func.count())\
                 .filter(Map.map_id==Game.map_id)\
@@ -75,13 +83,34 @@ class ServerInfo(object):
                 .group_by(Game.map_id)\
                 .group_by(Map.name) \
                 .order_by(expr.desc(func.count()))\
-                .limit(LEADERBOARD_COUNT)
+                .limit(LEADERBOARD_COUNT)\
+                .all()
         except:
             top_maps = None
 
         return top_maps
 
-    def _top_scorers(self):
+    def json(self):
+        """For rendering this data using JSON."""
+        top_maps = [{
+            "map_id": tm.map_id,
+            "map_name": tm.name,
+            "times_played": tm[2],
+        } for tm in self.top_maps]
+
+        return top_maps
+
+
+class ServerTopScorers(ServerInfoBase):
+    """Returns the top scorers on a given server."""
+
+    def __init__(self, request):
+        """Common parameter parsing."""
+
+        super(ServerTopScorers, self).__init__(request)
+        self.top_scorers = self.raw()
+
+    def raw(self):
         """Top scorers on this server by total score."""
         try:
             top_scorers = DBSession.query(Player.player_id, Player.nick,
@@ -97,16 +126,32 @@ class ServerInfo(object):
                 .group_by(Player.player_id)\
                 .limit(LEADERBOARD_COUNT)
 
-            # We can't call a Python function directly in our query, so we have to convert
-            # it out-of-band.
-            top_scorers = [(player_id, html_colors(nick), score)
-                           for (player_id, nick, score) in top_scorers]
         except:
             top_scorers = None
 
         return top_scorers
 
-    def _top_players(self):
+    def json(self):
+        """For rendering this data using JSON."""
+        top_scorers = [{
+            "player_id": ts.player_id,
+            "nick": ts.nick,
+            "score": ts[2],
+        } for ts in self.top_scorers]
+
+        return top_scorers
+
+
+class ServerTopPlayers(ServerInfoBase):
+    """Returns the top players by playing time on a given server."""
+
+    def __init__(self, request):
+        """Common parameter parsing."""
+
+        super(ServerTopPlayers, self).__init__(request)
+        self.top_players = self.raw()
+
+    def raw(self):
         """Top players on this server by total playing time."""
         try:
             top_players = DBSession.query(Player.player_id, Player.nick,
@@ -121,24 +166,45 @@ class ServerInfo(object):
                 .group_by(Player.player_id)\
                 .limit(LEADERBOARD_COUNT)
 
-            # We can't call a Python function directly in our query, so we have to convert
-            # it out-of-band.
-            top_players = [(player_id, html_colors(nick), score) \
-                    for (player_id, nick, score) in top_players]
-
         except:
             top_players = None
 
         return top_players
 
-    def _data(self):
-        """Returns the data shared by all renderers."""
+    def json(self):
+        """For rendering this data using JSON."""
+        top_players = [{
+            "player_id": ts.player_id,
+            "nick": ts.nick,
+            "time": ts[2].total_seconds(),
+        } for ts in self.top_players]
+
+        return top_players
+
+
+class ServerInfo(ServerInfoBase):
+    """Returns detailed information about a particular server."""
+
+    def __init__(self, request):
+        """Common parameter parsing."""
+
+        super(ServerInfo, self).__init__(request)
+        self.server_info = self.raw()
+
+    def raw(self):
+        """Returns the raw data shared by all renderers."""
         try:
             server = DBSession.query(Server).filter_by(server_id=self.server_id).one()
 
-            top_maps = self._top_maps()
-            top_scorers = self._top_scorers()
-            top_players = self._top_players()
+            top_maps = ServerTopMaps(self.request).top_maps
+
+            top_scorers_raw = ServerTopScorers(self.request).top_scorers
+            top_scorers = [(player_id, html_colors(nick), score)
+                           for (player_id, nick, score) in top_scorers_raw]
+
+            top_players_raw = ServerTopPlayers(self.request).top_players
+            top_players = [(player_id, html_colors(nick), score)
+                           for (player_id, nick, score) in top_players_raw]
 
             rgs = recent_games_q(server_id=self.server_id).limit(RECENT_GAMES_COUNT).all()
             recent_games = [RecentGame(row) for row in rgs]
@@ -159,4 +225,4 @@ class ServerInfo(object):
 
     def json(self):
         """For rendering this data using JSON."""
-        return {"status":"Not implemented"}
+        return {"status": "Not implemented"}

--- a/xonstat/views/server.py
+++ b/xonstat/views/server.py
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 # Defaults
 LEADERBOARD_LIFETIME = 30
 LEADERBOARD_COUNT = 10
+INDEX_COUNT = 20
 RECENT_GAMES_COUNT = 20
 
 
@@ -72,7 +73,7 @@ class ServerInfoBase(object):
 class ServerTopMaps(ServerInfoBase):
     """Returns the top maps played on a given server."""
 
-    def __init__(self, request, limit=LEADERBOARD_COUNT, last=None):
+    def __init__(self, request, limit=INDEX_COUNT, last=None):
         """Common parameter parsing."""
         super(ServerTopMaps, self).__init__(request, limit, last)
 
@@ -106,7 +107,17 @@ class ServerTopMaps(ServerInfoBase):
 
     def html(self):
         """Returns the HTML-ready representation."""
-        return self.top_maps
+
+        # build the query string
+        query = {}
+        if len(self.top_maps) > 1:
+            query['last'] = self.top_maps[-1].rank
+
+        return {
+            "server_id": self.server_id,
+            "top_maps": self.top_maps,
+            "query": query,
+        }
 
     def json(self):
         """For rendering this data using JSON."""
@@ -123,7 +134,7 @@ class ServerTopMaps(ServerInfoBase):
 class ServerTopScorers(ServerInfoBase):
     """Returns the top scorers on a given server."""
 
-    def __init__(self, request, limit=LEADERBOARD_COUNT, last=None):
+    def __init__(self, request, limit=INDEX_COUNT, last=None):
         """Common parameter parsing."""
         super(ServerTopScorers, self).__init__(request, limit, last)
         self.top_scorers = self.raw()
@@ -166,7 +177,17 @@ class ServerTopScorers(ServerInfoBase):
 
         top_scorers = [TopScorer(ts.rank, ts.player_id, html_colors(ts.nick), ts.total_score)
                        for ts in self.top_scorers]
-        return top_scorers
+
+        # build the query string
+        query = {}
+        if len(top_scorers) > 1:
+            query['last'] = top_scorers[-1].rank
+
+        return {
+            "server_id": self.server_id,
+            "top_scorers": top_scorers,
+            "query": query,
+        }
 
     def json(self):
         """For rendering this data using JSON."""
@@ -183,7 +204,7 @@ class ServerTopScorers(ServerInfoBase):
 class ServerTopPlayers(ServerInfoBase):
     """Returns the top players by playing time on a given server."""
 
-    def __init__(self, request, limit=LEADERBOARD_COUNT, last=None):
+    def __init__(self, request, limit=INDEX_COUNT, last=None):
         """Common parameter parsing."""
         super(ServerTopPlayers, self).__init__(request, limit, last)
         self.top_players = self.raw()
@@ -226,7 +247,16 @@ class ServerTopPlayers(ServerInfoBase):
         top_players = [TopPlayer(tp.rank, tp.player_id, html_colors(tp.nick), tp.alivetime)
                        for tp in self.top_players]
 
-        return top_players
+        # build the query string
+        query = {}
+        if len(top_players) > 1:
+            query['last'] = top_players[-1].rank
+
+        return {
+            "server_id": self.server_id,
+            "top_players": top_players,
+            "query": query,
+        }
 
     def json(self):
         """For rendering this data using JSON."""
@@ -273,9 +303,9 @@ class ServerInfo(ServerInfoBase):
         """For rendering this data using something HTML-based."""
         return {
             'server': self.server,
-            'top_players': self.top_players_v.html(),
-            'top_scorers': self.top_scorers_v.html(),
-            'top_maps': self.top_maps_v.html(),
+            'top_players': self.top_players_v.html()["top_players"],
+            'top_scorers': self.top_scorers_v.html()["top_scorers"],
+            'top_maps': self.top_maps_v.html()["top_maps"],
             'recent_games': self.recent_games,
             'lifetime': self.lifetime,
         }

--- a/xonstat/views/server.py
+++ b/xonstat/views/server.py
@@ -117,6 +117,7 @@ class ServerTopMaps(ServerInfoBase):
         return {
             "server_id": self.server_id,
             "top_maps": self.top_maps,
+            "lifetime": self.lifetime,
             "query": query,
         }
 
@@ -190,6 +191,7 @@ class ServerTopScorers(ServerInfoBase):
         return {
             "server_id": self.server_id,
             "top_scorers": top_scorers,
+            "lifetime": self.lifetime,
             "query": query,
         }
 
@@ -262,6 +264,7 @@ class ServerTopPlayers(ServerInfoBase):
         return {
             "server_id": self.server_id,
             "top_players": top_players,
+            "lifetime": self.lifetime,
             "query": query,
         }
 

--- a/xonstat/views/server.py
+++ b/xonstat/views/server.py
@@ -9,37 +9,33 @@ from xonstat.views.helpers import RecentGame, recent_games_q
 
 log = logging.getLogger(__name__)
 
-def _server_index_data(request):
-    if request.params.has_key('page'):
-        current_page = request.params['page']
-    else:
-        current_page = 1
 
-    try:
-        server_q = DBSession.query(Server).\
-                order_by(Server.server_id.desc())
+class ServerIndex(object):
 
-        servers = Page(server_q, current_page, items_per_page=25, url=page_url)
+    def __init__(self, request):
+        self.request = request
+        self.page = request.params.get("page", 1)
+        self.servers = self._data()
 
+    def _data(self):
+        try:
+            server_q = DBSession.query(Server).order_by(Server.server_id.desc())
+            servers = Page(server_q, self.page, items_per_page=25, url=page_url)
 
-    except Exception as e:
-        servers = None
+        except:
+            servers = None
 
-    return {'servers':servers, }
+        return servers
 
+    def html(self):
+        return {
+            'servers': self.servers,
+        }
 
-def server_index(request):
-    """
-    Provides a list of all the current servers.
-    """
-    return _server_index_data(request)
-
-
-def server_index_json(request):
-    """
-    Provides a list of all the current servers. JSON.
-    """
-    return [{'status':'not implemented'}]
+    def json(self):
+        return {
+            'servers': [s.to_dict() for s in self.servers],
+        }
 
 
 def _server_info_data(request):


### PR DESCRIPTION
This pull refactors all server-based views. The benefits and/or reasons for doing this are as follows:

- Move to class-based view callables so the HTML, JSON, and (in some cases) text renderers can share the same parameter parsing code. Class-based views also have the added benefit of allowing the view configurations to switch between different attributes of the class easily (attr=<method>).
- Add JSON responses for all server view content. One can access these by GETing the same URL with "Accept: application/json" as a header.
- Add three new views for all of the "top" stats on the top of the server info page. These now become accessible with their own HTML and JSON renderers. Pagination is done via the "last" query parameter, which tells the view which rank row was last seen.
- Update the so-called "lifetime" values of the data dynamically on the page. It was previously hard-coded to "7 days", which was incorrect. The text will now represent the actual value used. 

After much trial and error, I think I've found a basic skeleton that is maintainable for the rest of the codebase. I plan only to factor out some data-fetching logic into "thicker" models in the future, which would hopefully make things more testable. 
