### PR TITLE
Fix the active maps table and corresponding index.

### DIFF
--- a/xonstat/templates/main_index.mako
+++ b/xonstat/templates/main_index.mako
@@ -134,7 +134,7 @@
       % for tm in top_maps:
         <tr>
           <td>${tm.sort_order}</td>
-          <td>${tm.map_name}</td>
+          <td class="no-stretch"><a href="${request.route_url('map_info', id=tm.map_id)}" title="Go to the map info page for ${tm.map_name}">${tm.map_name}</a></td>
           <td>${tm.games}</td>
         </tr>
       % endfor

--- a/xonstat/templates/top_maps_index.mako
+++ b/xonstat/templates/top_maps_index.mako
@@ -32,7 +32,7 @@
           <tr>
             <td>${tm.sort_order}</td>
             <td class="no-stretch"><a href="${request.route_url('map_info', id=tm.map_id)}" title="Go to the map info page for ${tm.map_name}">${tm.map_name}</a></td>
-            <td>${tm.sort_order}</td>
+            <td>${tm.games}</td>
           </tr>
         % endfor
         </tbody>


### PR DESCRIPTION
After the "top maps" data was moved to pregenerated database tables, the links on the main page went away and a typo on the index pages showed the given map's rank twice. This pull fixes both of those things.