### PR TITLE
If no frag matrix row is found, show zeros.

### DIFF
--- a/xonstat/templates/frag_matrix.mako
+++ b/xonstat/templates/frag_matrix.mako
@@ -23,7 +23,12 @@
       else:
         victim_index = "-1"
     %>
+
+    % if pgfm:
     <td>${pgfm.matrix.get(victim_index, 0)}</td>
+    % else:
+    <td>0</td>
+    % endif
     % endfor
   </tr>
   % endfor


### PR DESCRIPTION
If a player has no frags, s/he won't have a frag matrix row, but will
still have a record in the player_game_stats table.